### PR TITLE
Fix: setting buffertools to empty object

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "test": "standard && tap test/*.js --coverage"
   },
+  "browser": {
+    "buffertools": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/othiym23/node-deeper.git"


### PR DESCRIPTION
Enroute to make node-tap browserifyable